### PR TITLE
Remove manual trigger

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
 
 jobs:
   terraform:


### PR DESCRIPTION
It will break since the first commit tried to get the last commits and if it won't have commits if manually triggered (or triggered twice in a row)